### PR TITLE
Added private_network_only flag to private vsi

### DIFF
--- a/terraform/compute.tf
+++ b/terraform/compute.tf
@@ -47,4 +47,5 @@ resource "ibm_compute_vm_instance" "compute_instances2" {
   private_security_group_ids = ["${ibm_security_group.sg2.id}"]
   local_disk = false
   private_vlan_id = "${var.privatevlanid}"
+  private_network_only = true
 }


### PR DESCRIPTION
The expectation for this solution is that one of the virtual servers that gets created is private only since it's only connected to a private VLAN (see arch diagram in readme)

Unfortunately I'm able to connect to the private VSI over the public network & a public IP is assigned to the virtual server. From the VSI's configuration properties it looks like a public VLAN was auto-assigned to it

The problem here is that the resource needs the private_network_only flag.

I've done high level test (provisioned VSI successfully, no public IP exposed & no public vlan attached). I haven't tested to make sure file storage is correctly mounted to the VSI. Please comment if additional tests are necessary